### PR TITLE
fixed hourly roll period's initial filename

### DIFF
--- a/src/store.cpp
+++ b/src/store.cpp
@@ -650,7 +650,12 @@ bool FileStore::openInternal(bool incrementFilename, struct tm* current_time) {
 
     // this is the case where there's no file there and we're not incrementing
     if (suffix < 0) {
-      suffix = 0;
+      if (rollPeriod == ROLL_HOURLY) {
+        suffix = current_time->tm_hour;
+      }
+      else {
+        suffix = 0;
+      }
     }
 
     string file = makeFullFilename(suffix, current_time);


### PR DESCRIPTION
When rotate_period=hourly and no logs exist for a given category,
the log's filename is created incorrectly. The filename suffix is 0,
when it should be the current hour.
