### PR TITLE
Modifications to scribe periodic rotations for file store

### DIFF
--- a/src/store.cpp
+++ b/src/store.cpp
@@ -395,8 +395,11 @@ void FileStoreBase::periodicCheck() {
       case ROLL_NEVER:
         break;
     }
-	// Do periodic roll up only if you have some messages	
-	rotate = rotateIfData ? (currentSize > 0) : rotate;
+
+  	// Do periodic roll up only if you have some messages	
+    if(rotate) {
+  	  rotate = rotateIfData ? (currentSize > 0) : rotate;
+    }
   }
 
   if (rotate) {

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -198,6 +198,7 @@ FileStoreBase::FileStoreBase(StoreQueue* storeq,
     createSymlink(true),
     writeStats(false),
     rotateOnReopen(false),
+    rotateIfData(false),
     currentSize(0),
     lastRollTime(0),
     eventsWritten(0) {
@@ -324,6 +325,12 @@ void FileStoreBase::configure(pStoreConf configuration, pStoreConf parent) {
       rotateOnReopen = false;
     }
   }
+
+  if (configuration->getString("rotate_if_data", tmp)) {
+    if (0 == tmp.compare("yes")) {
+      rotateIfData = true;
+    }
+  }
 }
 
 void FileStoreBase::copyCommon(const FileStoreBase *base) {
@@ -342,6 +349,7 @@ void FileStoreBase::copyCommon(const FileStoreBase *base) {
   baseSymlinkName = base->baseSymlinkName;
   writeStats = base->writeStats;
   rotateOnReopen = base->rotateOnReopen;
+  rotateIfData = base->rotateIfData;
 
   /*
    * append the category name to the base file path and change the
@@ -387,6 +395,8 @@ void FileStoreBase::periodicCheck() {
       case ROLL_NEVER:
         break;
     }
+	// Do periodic roll up only if you have some messages	
+	rotate = rotateIfData ? (currentSize > 0) : rotate;
   }
 
   if (rotate) {

--- a/src/store.h
+++ b/src/store.h
@@ -167,6 +167,7 @@ class FileStoreBase : public Store {
   bool createSymlink;
   bool writeStats;
   bool rotateOnReopen;
+  bool rotateIfData;
 
   // State
   unsigned long currentSize;


### PR DESCRIPTION
Hi,

The current periodic file rotations scheme provided by Scribe is very efficient. It works very well when you have single scribe server which is doing all the pushing. However, there is a slight problem with it when you employ multiple scribe server behind a load balancer to balance the load. At a time, the load balancer routes the data only through one scribe server but since the concerned category is configured on all the scribe servers, the other scribe servers will keep on doing the rotations and creates the 0 byte files in HDFS/file system. The less the intervals, the more the files will be created.

To solve this, I am attaching a patch which enables a new configuration directive "rotate_if_data" which allows scribe to perform periodic file rotations if and only if there are messages in buffer. If there are no messages, it will skip that rotation period. The default value for this configuration parameter is "false".

Please review it. If you'd like me to modify anything else or if there are any issues with it, please let me know.

Thanks,
Deepesh
