### PR TITLE
Fix build on newer platforms (latest Mac OS X, Ubuntu 11.10)

### DIFF
--- a/global_header.mk
+++ b/global_header.mk
@@ -4,7 +4,7 @@
 #endef
 
 define thrift_template
-XTARGET := $(shell perl -e '@val = split("\/","$(2)"); $$last = pop(@val);split("\\.",$$last);print "$(1)/"."gen-cpp/"."@_[0]"."_types.cpp\n"' )
+XTARGET := $(shell perl -e '$$_ = $$ARGV[1]; s{^.*/}{}; s{\..*}{}; print "$$ARGV[0]/gen-cpp/$${_}_types.cpp\n"' '$(1)' '$(2)')
 
 ifneq ($$(XBUILT_SOURCES),) 
     XBUILT_SOURCES := $$(XBUILT_SOURCES) $$(XTARGET)


### PR DESCRIPTION
fix build on systems with Perl > 5.12.0 (Ubuntu 11.10 Oneiric, Mac OS X) due to split() incompatibility

thanks mauke from #perl on freenode!

> split() no longer modifies @_ when called in scalar or void context. In void context it now produces a "Useless use of split" warning. This was also a perl 5.12.0 change that missed the perldelta.

from http://perldoc.perl.org/perl5140delta.html
