### PR TITLE
Fix building on GCC 4.6

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,7 +72,7 @@ AM_CPPFLAGS += -I$(hadoop_home)/include
 AM_CPPFLAGS += $(BOOST_CPPFLAGS)
 AM_CPPFLAGS += $(FB_CPPFLAGS) $(DEBUG_CPPFLAGS)
 
-AM_LDFLAGS = $(BOOST_LDFLAGS) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
+AM_LDFLAGS = -Wl,--no-as-needed $(BOOST_LDFLAGS) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
 
 # Section 3 #############################################################################
 # GENERATE BUILD RULES


### PR DESCRIPTION
This commit fixes building on GCC 4.6 where the linker ignores libraries it find not needed (ie. not used by any object scanned so far). This behaviour can be changed by adding "-Wl,--no-as-needed" to the gcc arguments.
