### PR TITLE
Fixes for compiler warnings, bug fix in File store type, documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ install-sh
 missing
 mkinstalldirs
 *.o
+configure
+Makefile.in
+aclocal.m4
+autom4te.cache

--- a/aclocal/ax_boost_regex.m4
+++ b/aclocal/ax_boost_regex.m4
@@ -1,0 +1,111 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_regex.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_REGEX
+#
+# DESCRIPTION
+#
+#   Test for Regex library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_REGEX_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_REGEX
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2008 Michael Tindal
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 19
+
+AC_DEFUN([AX_BOOST_REGEX],
+[
+	AC_ARG_WITH([boost-regex],
+	AS_HELP_STRING([--with-boost-regex@<:@=special-lib@:>@],
+                   [use the Regex library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-regex=boost_regex-gcc-mt-d-1_33_1 ]),
+        [
+        if test "$withval" = "no"; then
+			want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_regex_lib=""
+        else
+		    want_boost="yes"
+		ax_boost_user_regex_lib="$withval"
+		fi
+        ],
+        [want_boost="yes"]
+	)
+
+	if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
+
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::Regex library is available,
+					   ax_cv_boost_regex,
+        [AC_LANG_PUSH([C++])
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/regex.hpp>
+												]],
+                                   [[boost::regex r(); return 0;]])],
+                   ax_cv_boost_regex=yes, ax_cv_boost_regex=no)
+         AC_LANG_POP([C++])
+		])
+		if test "x$ax_cv_boost_regex" = "xyes"; then
+			AC_DEFINE(HAVE_BOOST_REGEX,,[define if the Boost::Regex library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+            if test "x$ax_boost_user_regex_lib" = "x"; then
+                for libextension in `ls $BOOSTLIBDIR/libboost_regex*.so* $BOOSTLIBDIR/libboost_regex*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_regex.*\)\.so.*$;\1;' -e 's;^lib\(boost_regex.*\)\.a*$;\1;'` ; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_REGEX_LIB="-l$ax_lib"; AC_SUBST(BOOST_REGEX_LIB) link_regex="yes"; break],
+                                 [link_regex="no"])
+				done
+                if test "x$link_regex" != "xyes"; then
+                for libextension in `ls $BOOSTLIBDIR/boost_regex*.{dll,a}* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_regex.*\)\.dll.*$;\1;' -e 's;^\(boost_regex.*\)\.a*$;\1;'` ; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_REGEX_LIB="-l$ax_lib"; AC_SUBST(BOOST_REGEX_LIB) link_regex="yes"; break],
+                                 [link_regex="no"])
+				done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_regex_lib boost_regex-$ax_boost_user_regex_lib; do
+				      AC_CHECK_LIB($ax_lib, main,
+                                   [BOOST_REGEX_LIB="-l$ax_lib"; AC_SUBST(BOOST_REGEX_LIB) link_regex="yes"; break],
+                                   [link_regex="no"])
+               done
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+			if test "x$link_regex" != "xyes"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+			fi
+		fi
+
+		CPPFLAGS="$CPPFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
+	fi
+])

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,7 @@ FB_WITH_PATH([hadoop_home], [hadooppath], [/usr/local])
 AX_BOOST_BASE([1.36])
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
+AX_BOOST_REGEX
 
 # Generates Makefile from Makefile.am. Modify when new subdirs are added.
 # Change Makefile.am also to add subdirectly.

--- a/examples/README
+++ b/examples/README
@@ -41,6 +41,8 @@ src/scribed examples/example1.conf
 #From another terminal, use scribe_cat to send a message to scribe:
 echo "hello world" | examples/scribe_cat test
 
+#Note that extra newline after "hello world" from example1.conf's add_newlines
+
 #If the previous command failed, make sure you did a 'make install' from the
 #root scribe directory and that $PYTHONPATH is set correctly (see README)
 

--- a/examples/README
+++ b/examples/README
@@ -39,22 +39,22 @@ mkdir /tmp/scribetest
 src/scribed examples/example1.conf
 
 #From another terminal, use scribe_cat to send a message to scribe:
-echo "hello world" | ./scribe_cat test
+echo "hello world" | examples/scribe_cat test
 
 #If the previous command failed, make sure you did a 'make install' from the
-#root scribe directory and that $PYTHONPATH is set correctly(see README.BUILD)
+#root scribe directory and that $PYTHONPATH is set correctly (see README)
 
 #Verify that the message got logged:
 cat /tmp/scribetest/test/test_current
 
 #Check the status of scribe (requires root):
-./scribe_ctrl status
+examples/scribe_ctrl status
 
 #Check scribe's counters (you should see 1 message 'received good'):
-./scribe_ctrl counters
+examples/scribe_ctrl counters
 
 #Shutdown scribe:
-./scribe_ctrl stop
+examples/scribe_ctrl stop
 
 
 #
@@ -80,7 +80,7 @@ cat /tmp/scribetest/test/test_current
                                    -------------------
 
 
-#Create a directory for the second scribe instance:
+#Create a directory for the second scribe instance (used in example2client.conf):
 mkdir /tmp/scribetest2
 
 #Start up the 'central' instance of Scribe on port 1463 to write messages to disk
@@ -92,14 +92,15 @@ src/scribed examples/example2central.conf
 src/scribed examples/example2client.conf
 
 #Use scribe_cat to send some messages to the 'client' Scribe instance:
-echo "test message" | ./scribe_cat -h localhost:1464 test2
+echo "test message" | examples/scribe_cat -h localhost:1464 test2
 
-echo "this message will be ignored" | ./scribe_cat -h localhost:1464 ignore_me
+echo "this message will be ignored" | examples/scribe_cat -h localhost:1464 ignore_me
 
-echo "123:this message will be bucketed" | ./scribe_cat -h localhost:1464 bucket_me
+echo "123:this message will be bucketed" | examples/scribe_cat -h localhost:1464 bucket_me
 
 #The first message will be logged similar to example 1.
-#The second message will not get logged.
+#The second message will not get logged on the central server and will be
+#forgotten by the client server. The ignore_me dir will remain.
 #The third message will be bucketized into 1 of 5 buckets
 #(See example2central.conf)
 
@@ -110,14 +111,14 @@ cat /tmp/scribetest/test2/test2_current
 cat /tmp/scribetest/bucket*/bucket_me_current
 
 #Check the status and counters of both instances:
-./scribe_ctrl status 1463
-./scribe_ctrl status 1464
-./scribe_ctrl counters 1463
-./scribe_ctrl counters 1464
+examples/scribe_ctrl status 1463
+examples/scribe_ctrl status 1464
+examples/scribe_ctrl counters 1463
+examples/scribe_ctrl counters 1464
 
 #Shutdown both servers:
-./scribe_ctrl stop 1463
-./scribe_ctrl stop 1464
+examples/scribe_ctrl stop 1463
+examples/scribe_ctrl stop 1464
 
 
 #
@@ -134,39 +135,39 @@ src/scribed examples/example2central.conf
 src/scribed examples/example2client.conf
 
 #Log a message to the 'client' Scribe instance:
-echo "test message 1" | ./scribe_cat -h localhost:1464 test3
+echo "test message 1" | examples/scribe_cat -h localhost:1464 test3
 
 #Verify that the message got logged:
 cat /tmp/scribetest/test3/test3_current
 
 #Stop the 'central' Scribe instance:
-./scribe_ctrl stop 1463
+examples/scribe_ctrl stop 1463
 
 #Attempting to check the status of this server will return failure since it not running:
-./scribe_ctrl status 1463
+examples/scribe_ctrl status 1463
 
 #Try to Log another message:
-echo "test message 2" | ./scribe_cat -h localhost:1464 test3
+echo "test message 2" | examples/scribe_cat -h localhost:1464 test3
 
 #This message will be buffered by the 'client' since it cannot be forwarded to
 #the 'central' server.  Scribe will keep retrying until it is able to send.
 
 #After a couple seconds, the status of the 'client' will be set to a warning message:
-./scribe_ctrl status 1464
+examples/scribe_ctrl status 1464
 
 #Try to Log yet another message(which will also get buffered):
-echo "test message 3" | ./scribe_cat -h localhost:1464 test3
+echo "test message 3" | examples/scribe_cat -h localhost:1464 test3
 
 #Restart the 'central' instance:
 src/scribed examples/example2central.conf
 
 #Wait for both Scribe instance's statuses to change to ALIVE:
-./scribe_ctrl status 1463
-./scribe_ctrl status 1464
+examples/scribe_ctrl status 1463
+examples/scribe_ctrl status 1464
 
 #Verify that all 3 messages have now been received by the 'central' server:
 cat /tmp/scribetest/test3/test3_current
 
 #Shutdown:
-./scribe_ctrl stop 1463
-./scribe_ctrl stop 1464
+examples/scribe_ctrl stop 1463
+examples/scribe_ctrl stop 1464

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -4,3 +4,6 @@ gen-php
 gen-py
 gen-java
 scribed
+libdynamicbucketupdater.a
+libscribe.a
+Makefile.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,7 +72,7 @@ AM_CPPFLAGS += -I$(hadoop_home)/include
 AM_CPPFLAGS += $(BOOST_CPPFLAGS)
 AM_CPPFLAGS += $(FB_CPPFLAGS) $(DEBUG_CPPFLAGS)
 
-AM_LDFLAGS = $(BOOST_LDFLAGS) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
+AM_LDFLAGS = $(BOOST_LDFLAGS) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_REGEX_LIB)
 
 # Section 3 #############################################################################
 # GENERATE BUILD RULES

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -310,7 +310,6 @@ ostream& StoreConf::print(ostream& os, uint32_t depth,
   // are weakly ordered, so we will get consistent output.
   for (string_map_t::const_iterator iter = values.begin();
         iter != values.end(); iter++) {
-    int len = useSpace ? depth * tabw : depth;
     os << indent(depth, useSpace, tabw) << iter->first
        << "=" << iter->second << endl;
   }

--- a/src/dynamic_bucket_updater.cpp
+++ b/src/dynamic_bucket_updater.cpp
@@ -1,4 +1,4 @@
-#include <strstream>
+#include <sstream>
 #include <iostream>
 #include "dynamic_bucket_updater.h"
 #include "scribe_server.h"

--- a/src/scribe_server.cpp
+++ b/src/scribe_server.cpp
@@ -288,7 +288,6 @@ bool scribeHandler::throttleRequest(const vector<LogEntry>&  messages) {
   // Also note that we always check all categories, not just the ones in this request.
   // This is a simplification based on the assumption that most Log() calls contain most
   // categories.
-  unsigned long long max_count = 0;
   for (category_map_t::iterator cat_iter = categories.begin();
        cat_iter != categories.end();
        ++cat_iter) {

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -1743,15 +1743,15 @@ NetworkStore::NetworkStore(StoreQueue* storeq,
     serviceBased(false),
     remotePort(0),
     serviceCacheTimeout(DEFAULT_NETWORKSTORE_CACHE_TIMEOUT),
+    lastServiceCheck(0),
     ignoreNetworkError(false),
     configmod(NULL),
-    opened(false),
-    lastServiceCheck(0) {
   // we can't open the connection until we get configured
 
   // the bool for opened ensures that we don't make duplicate
   // close calls, which would screw up the connection pool's
   // reference counting.
+    opened(false) {
 }
 
 NetworkStore::~NetworkStore() {

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -476,7 +476,7 @@ string FileStoreBase::makeBaseFilename(struct tm* creation_time) {
 // returns the suffix of the newest file matching base_filename
 int FileStoreBase::findNewestFile(struct tm* creation_time) {
 
-  string base_filename = makeFilePath(creation_time);
+  string base_filename = makeBaseFilename(creation_time);
   string filePath = makeFilePath(creation_time);
   std::vector<std::string> files = FileInterface::list(filePath, fsType);
 
@@ -496,7 +496,7 @@ int FileStoreBase::findNewestFile(struct tm* creation_time) {
 
 int FileStoreBase::findOldestFile(struct tm* creation_time) {
 
-  string base_filename = makeFilePath(creation_time);
+  string base_filename = makeBaseFilename(creation_time);
   string filePath = makeFilePath(creation_time);
 
   std::vector<std::string> files = FileInterface::list(filePath, fsType);

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -25,6 +25,7 @@
 // @author John Song
 
 #include <algorithm>
+#include <boost/regex.hpp>
 #include "common.h"
 #include "scribe_server.h"
 #include "network_dynamic_config.h"
@@ -182,7 +183,6 @@ FileStoreBase::FileStoreBase(StoreQueue* storeq,
   : Store(storeq, category, type, multi_category),
     baseFilePath("/tmp"),
     subDirectory(""),
-    filePath("/tmp"),
     baseFileName(category),
     baseSymlinkName(""),
     maxSize(DEFAULT_FILESTORE_MAX_SIZE),
@@ -218,11 +218,6 @@ void FileStoreBase::configure(pStoreConf configuration, pStoreConf parent) {
 
   if (0 == tmp.compare("yes")) {
     setHostNameSubDir();
-  }
-
-  filePath = baseFilePath;
-  if (!subDirectory.empty()) {
-    filePath += "/" + subDirectory;
   }
 
 
@@ -349,10 +344,6 @@ void FileStoreBase::copyCommon(const FileStoreBase *base) {
    * unique
    */
   baseFilePath = base->baseFilePath + std::string("/") + categoryHandled;
-  filePath = baseFilePath;
-  if (!subDirectory.empty()) {
-    filePath += "/" + subDirectory;
-  }
 
   baseFileName = categoryHandled;
 }
@@ -405,9 +396,37 @@ void FileStoreBase::rotateFile(time_t currentTime) {
            makeBaseFilename(&timeinfo).c_str(), currentSize,
            maxSize == ULONG_MAX ? 0 : maxSize);
 
-  printStats();
+  printStats(&timeinfo);
   openInternal(true, &timeinfo);
 }
+
+static const boost::regex filename_replace_re(
+      "(\\$\\{YEAR\\})|"
+      "(\\$\\{MONTH\\})|"
+      "(\\$\\{DAY\\})|"
+      "(\\$\\{HOUR\\})");
+
+
+string FileStoreBase::substituteFilenameString(string &orig_filename, struct tm* creation_time) {
+  ostringstream formatstring;
+  formatstring
+         << "(?{1}" <<                creation_time->tm_year + 1900 << ')'
+         << "(?{2}" << setw(2) << setfill('0') << creation_time->tm_mon + 1 << ')'
+         << "(?{3}" << setw(2) << setfill('0') << creation_time->tm_mday << ')'
+         << "(?{4}" << setw(2) << setfill('0') << creation_time->tm_hour << ')'
+     ;
+
+  return boost::regex_replace(orig_filename, filename_replace_re, formatstring.str(), boost::match_default | boost::format_all);
+}
+
+string FileStoreBase::makeFilePath(struct tm* creation_time) {
+  if (!subDirectory.empty()) {
+    return baseFilePath + "/" + substituteFilenameString(subDirectory, creation_time);
+  } else {
+    return baseFilePath;
+  }
+}
+
 
 string FileStoreBase::makeFullFilename(int suffix, struct tm* creation_time,
                                        bool use_full_path) {
@@ -415,7 +434,9 @@ string FileStoreBase::makeFullFilename(int suffix, struct tm* creation_time,
   ostringstream filename;
 
   if (use_full_path) {
-    filename << filePath << '/';
+    filename << makeFilePath(creation_time) << '/';
+  } else if (!subDirectory.empty()) {
+    filename << substituteFilenameString(subDirectory, creation_time) << '/';
   }
   filename << makeBaseFilename(creation_time);
   filename << '_' << setw(5) << setfill('0') << suffix;
@@ -433,9 +454,9 @@ string FileStoreBase::makeBaseSymlink() {
   return base.str();
 }
 
-string FileStoreBase::makeFullSymlink() {
+string FileStoreBase::makeFullSymlink(struct tm* creation_time) {
   ostringstream filename;
-  filename << filePath << '/' << makeBaseSymlink();
+  filename << makeFilePath(creation_time) << '/' << makeBaseSymlink();
   return filename.str();
 }
 
@@ -453,8 +474,10 @@ string FileStoreBase::makeBaseFilename(struct tm* creation_time) {
 }
 
 // returns the suffix of the newest file matching base_filename
-int FileStoreBase::findNewestFile(const string& base_filename) {
+int FileStoreBase::findNewestFile(struct tm* creation_time) {
 
+  string base_filename = makeFilePath(creation_time);
+  string filePath = makeFilePath(creation_time);
   std::vector<std::string> files = FileInterface::list(filePath, fsType);
 
   int max_suffix = -1;
@@ -471,7 +494,10 @@ int FileStoreBase::findNewestFile(const string& base_filename) {
   return max_suffix;
 }
 
-int FileStoreBase::findOldestFile(const string& base_filename) {
+int FileStoreBase::findOldestFile(struct tm* creation_time) {
+
+  string base_filename = makeFilePath(creation_time);
+  string filePath = makeFilePath(creation_time);
 
   std::vector<std::string> files = FileInterface::list(filePath, fsType);
 
@@ -507,12 +533,13 @@ int FileStoreBase::getFileSuffix(const string& filename,
   return suffix;
 }
 
-void FileStoreBase::printStats() {
+void FileStoreBase::printStats(struct tm* creation_time) {
   if (!writeStats) {
     return;
   }
 
-  string filename(filePath);
+  string filePath = makeFilePath(creation_time);
+  string filename = filePath;
   filename += "/scribe_stats";
 
   boost::shared_ptr<FileInterface> stats_file =
@@ -641,8 +668,10 @@ bool FileStore::openInternal(bool incrementFilename, struct tm* current_time) {
     current_time = &timeinfo;
   }
 
+  string filePath = makeFilePath(current_time);
+
   try {
-    int suffix = findNewestFile(makeBaseFilename(current_time));
+    int suffix = findNewestFile(current_time);
 
     if (incrementFilename) {
       ++suffix;
@@ -710,7 +739,7 @@ bool FileStore::openInternal(bool incrementFilename, struct tm* current_time) {
 
       /* just make a best effort here, and don't error if it fails */
       if (createSymlink && !isBufferFile) {
-        string symlinkName = makeFullSymlink();
+        string symlinkName = makeFullSymlink(current_time);
         boost::shared_ptr<FileInterface> tmp =
           FileInterface::createFileInterface(fsType, symlinkName, isBufferFile);
         tmp->deleteFile();
@@ -903,7 +932,7 @@ bool FileStore::writeMessages(boost::shared_ptr<logentry_vector_t> messages,
 // currently gets invoked from within a bufferstore
 void FileStore::deleteOldest(struct tm* now) {
 
-  int index = findOldestFile(makeBaseFilename(now));
+  int index = findOldestFile(now);
   if (index < 0) {
     return;
   }
@@ -920,7 +949,7 @@ void FileStore::deleteOldest(struct tm* now) {
 bool FileStore::replaceOldest(boost::shared_ptr<logentry_vector_t> messages,
                               struct tm* now) {
   string base_name = makeBaseFilename(now);
-  int index = findOldestFile(base_name);
+  int index = findOldestFile(now);
   if (index < 0) {
     LOG_OPER("[%s] Could not find files <%s>", categoryHandled.c_str(), base_name.c_str());
     return false;
@@ -957,7 +986,7 @@ bool FileStore::readOldest(/*out*/ boost::shared_ptr<logentry_vector_t> messages
 
   long loss;
 
-  int index = findOldestFile(makeBaseFilename(now));
+  int index = findOldestFile(now);
   if (index < 0) {
     // This isn't an error. It's legit to call readOldest when there aren't any
     // files left, in which case the call succeeds but returns messages empty.
@@ -1015,6 +1044,7 @@ bool FileStore::readOldest(/*out*/ boost::shared_ptr<logentry_vector_t> messages
 }
 
 bool FileStore::empty(struct tm* now) {
+  string filePath = makeFilePath(now);
   std::vector<std::string> files = FileInterface::list(filePath, fsType);
 
   std::string base_filename = makeBaseFilename(now);
@@ -1135,7 +1165,7 @@ bool ThriftFileStore::openInternal(bool incrementFilename, struct tm* current_ti
   }
   int suffix;
   try {
-    suffix = findNewestFile(makeBaseFilename(current_time));
+    suffix = findNewestFile(current_time);
   } catch(const std::exception& e) {
     LOG_OPER("Exception < %s > in ThriftFileStore::openInternal",
       e.what());
@@ -1153,7 +1183,7 @@ bool ThriftFileStore::openInternal(bool incrementFilename, struct tm* current_ti
 
   string filename = makeFullFilename(suffix, current_time);
   /* try to create the directory containing the file */
-  if (!createFileDirectory()) {
+  if (!createFileDirectory(current_time)) {
     LOG_OPER("[%s] Could not create path for file: %s",
              categoryHandled.c_str(), filename.c_str());
     return false;
@@ -1213,7 +1243,7 @@ bool ThriftFileStore::openInternal(bool incrementFilename, struct tm* current_ti
 
   /* just make a best effort here, and don't error if it fails */
   if (createSymlink) {
-    string symlinkName = makeFullSymlink();
+    string symlinkName = makeFullSymlink(current_time);
     unlink(symlinkName.c_str());
     string symtarget = makeFullFilename(suffix, current_time, false);
     symlink(symtarget.c_str(), symlinkName.c_str());
@@ -1222,7 +1252,8 @@ bool ThriftFileStore::openInternal(bool incrementFilename, struct tm* current_ti
   return true;
 }
 
-bool ThriftFileStore::createFileDirectory () {
+bool ThriftFileStore::createFileDirectory (struct tm* current_time) {
+  string filePath = makeFilePath(current_time);
   try {
     boost::filesystem::create_directories(filePath);
   } catch(const std::exception& e) {

--- a/src/store.h
+++ b/src/store.h
@@ -129,21 +129,26 @@ class FileStoreBase : public Store {
 
   // appends information about the current file to a log file in the same
   // directory
-  virtual void printStats();
+  virtual void printStats(struct tm* creation_time);
 
   // Returns the number of bytes to pad to align to the specified block size
   unsigned long bytesToPad(unsigned long next_message_length,
                            unsigned long current_file_size,
                            unsigned long chunk_size);
 
+  std::string makeFilePath(struct tm* creation_time);
+
   // A full filename includes an absolute path and a sequence number suffix.
   std::string makeBaseFilename(struct tm* creation_time);
   std::string makeFullFilename(int suffix, struct tm* creation_time,
                                bool use_full_path = true);
+
+  std::string substituteFilenameString(std::string &orig_filename, struct tm* creation_time);
+
   std::string makeBaseSymlink();
-  std::string makeFullSymlink();
-  int  findOldestFile(const std::string& base_filename);
-  int  findNewestFile(const std::string& base_filename);
+  std::string makeFullSymlink(struct tm* creation_time);
+  int  findOldestFile(struct tm* creation_time);
+  int  findNewestFile(struct tm* creation_time);
   int  getFileSuffix(const std::string& filename,
                      const std::string& base_filename);
   void setHostNameSubDir();
@@ -151,7 +156,6 @@ class FileStoreBase : public Store {
   // Configuration
   std::string baseFilePath;
   std::string subDirectory;
-  std::string filePath;
   std::string baseFileName;
   std::string baseSymlinkName;
   unsigned long maxSize;
@@ -249,7 +253,7 @@ class ThriftFileStore : public FileStoreBase {
   void configure(pStoreConf configuration, pStoreConf parent);
   void close();
   void flush();
-  bool createFileDirectory();
+  bool createFileDirectory(struct tm* current_time);
 
  protected:
   // Implement FileStoreBase virtual function

--- a/src/store.h
+++ b/src/store.h
@@ -325,9 +325,9 @@ class BufferStore : public Store {
   bool   replayBuffer;            // whether to send buffers from
                                   // secondary store to primary
   bool adaptiveBackoff;           // Adaptive backoff mode indicator
-  unsigned long minRetryInterval; // The min the retryInterval can become
-  unsigned long maxRetryInterval; // The max the retryInterval can become
-  unsigned long maxRandomOffset;  // The max random offset added
+  time_t minRetryInterval;        // The min the retryInterval can become
+  time_t maxRetryInterval;        // The max the retryInterval can become
+  time_t maxRandomOffset;         // The max random offset added
                                   // to the retry interval
 
 


### PR DESCRIPTION
This is a small assortment of changes that I've made to get scribe to work for me with gcc 4.4.5 (Debian's build), a bug fix for the File store type that prevented the findOldestFile and findNewestFile calls from finding the files that were intended, and some documentation fixes.
