### PR TITLE
Fix to add new line char to meta line, when both options are enabled

### DIFF
--- a/src/store.cpp
+++ b/src/store.cpp
@@ -677,6 +677,9 @@ bool FileStore::openInternal(bool incrementFilename, struct tm* current_time) {
     if (writeFile) {
       if (writeMeta) {
         writeFile->write(meta_logfile_prefix + file);
+	if (addNewlines) {
+	  writeFile->write("\n");
+	}
       }
       writeFile->close();
     }


### PR DESCRIPTION
When the option to add a new line char to the end of each line is enabled, the code was not appending one to the final meta line.
