### PR TITLE
the build seems to forget to link some files in shared mode...

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,11 +91,14 @@ endif
 # Shared -- multiple libraries can be defined
 if SHARED
 shareddir = $(prefix)/lib
-shared_PROGRAMS = libscribe.so
+shared_PROGRAMS = libscribe.so libdynamicbucketupdater.so
 libscribe_so_SOURCES = gen-cpp/scribe.cpp gen-cpp/scribe_types.cpp
+libdynamicbucketupdater_so_SOURCES = gen-cpp/BucketStoreMapping.cpp gen-cpp/bucketupdater_constants.cpp gen-cpp/bucketupdater_types.cpp 
 libscribe_so_CXXFLAGS = $(SHARED_CXXFLAGS)
+libdynamicbucketupdater_so_CXXFLAGS = $(SHARED_CXXFLAGS)
 libscribe_so_LDFLAGS = $(SHARED_LDFLAGS)
-INTERNAL_LIBS =  libscribe.so
+libdynamicbucketupdater_so_LDFLAGS = $(SHARED_LDFLAGS)
+INTERNAL_LIBS =  libscribe.so libdynamicbucketupdater.so
 endif
 
 # Binaries -- multiple progs can be defined.
@@ -107,7 +110,7 @@ endif
 scribed_LDADD = $(EXTERNAL_LIBS) $(INTERNAL_LIBS)
 
 if SHARED
-scribed_DEPENDENCIES = libscribe.so
+scribed_DEPENDENCIES = libscribe.so libdynamicbucketupdater.so
 endif
 
 # Section 4 ##############################################################################


### PR DESCRIPTION
Without this patch, my build died when linking scribed:

g++  -Wall -O3 -L/usr/lib -lboost_system -lboost_filesystem  -o scribed store.o store_queue.o conf.o file.o conn_pool.o scribe_server.o network_dynamic_config.o dynamic_bucket_updater.o  env_default.o  -L/usr/lib -L/usr/lib -L/usr/local/lib -lfb303 -lthrift -lthriftnb -levent -lpthread  libscribe.so 
dynamic_bucket_updater.o: In function `DynamicBucketUpdater::updateInternal(std::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, std::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int, unsigned int, unsigned int)':
dynamic_bucket_updater.cpp:(.text+0xc9e): undefined reference to`vtable for scribe::thrift::BucketStoreMappingClient'
...
