### PR TITLE
From Boost.Filesystem >1.45 class member directory_entry->leaf()(248:file.cpp) removed 

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -245,7 +245,7 @@ void StdFile::listImpl(const std::string& path, std::vector<std::string>& _retur
       boost::filesystem::directory_iterator dir_iter(path), end_iter;
 
       for ( ; dir_iter != end_iter; ++dir_iter) {
-        _return.push_back(dir_iter->filename());
+		_return.push_back(dir_iter->path().filename().string());
       }
     }
   } catch (const std::exception& e) {


### PR DESCRIPTION
Boost.Filesystem deprecates the old names and features. According to this http://www.boost.org/doc/libs/1_45_0/libs/filesystem/v3/doc/deprecated.html Boost.Filesystem class directory_entry now doesn`t have member leaf(), instead we must use path().filename(). Building Scribe with new boost library will failed with error error: Б─≤class boost::filesystem::directory_entry has no member named leaf. 
Patch will use path().filename().string() instead in file.cpp
