### PR TITLE
Fixed automake 1.14 bug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,8 +10,8 @@
 AC_PREREQ(2.52)
 AC_INIT([scribe], [1.5.0])
 AC_CONFIG_MACRO_DIR([aclocal])
-AM_INIT_AUTOMAKE([foreign -Wall])
-# To install locally
+# AM_INIT_AUTOMAKE([foreign -Wall])
+# To install locally (AM_INIT_AUTOMAKE or FB_INITIALIZE, not both)
 FB_INITIALIZE([localinstall])
 AC_PREFIX_DEFAULT([/usr/local])
 


### PR DESCRIPTION
automake 1.14 would fail with global options already processed, due to AM_INIT_AUTOMAKE being called twice (top of configure.ac and in FB_INITIALIZE)

Fixes installations issues on systems with automake 1.14, such as [FreeBSD 9.1](http://forums.freebsd.org/showthread.php?t=40903) or OS X (#51)
