### PR TITLE
Add a method of specifying multiple upstream hosts in a Network store

### DIFF
--- a/src/store.h
+++ b/src/store.h
@@ -387,14 +387,19 @@ class NetworkStore : public Store {
 
  protected:
   static const long int DEFAULT_SOCKET_TIMEOUT_MS = 5000; // 5 sec timeout
+  bool loadFromList(const std::string &list, unsigned long defaultPort,
+                    server_vector_t& _return);
 
   // configuration
   bool useConnPool;
   bool serviceBased;
+  bool listBased;
   long int timeout;
   std::string remoteHost;
   unsigned long remotePort; // long because it works with config code
   std::string serviceName;
+  std::string serviceList;
+  unsigned long serviceListDefaultPort;
   std::string serviceOptions;
   server_vector_t servers;
   unsigned long serviceCacheTimeout;


### PR DESCRIPTION
A small extension to NetworkStore to allow SMC-like multiple upstreams, but specified as a space-delimited list in the config file.

scribed will connect to one of the upstreams and continue to use it until it fails, then reconnect to a different one and backfill from the secondary store automatically.
