### PR TITLE
Bugfix for the automake ("global options already processed") error

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,4 +2,4 @@
 
 # To be safe include -I flag
 autoreconf --force --verbose --install
-./configure --config-cache $*
+./configure --with-boost-system=boost_system --with-boost-filesystem=boost_filesystem --config-cache $*

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 AC_PREREQ(2.52)
 AC_INIT([scribe], [1.5.0])
 AC_CONFIG_MACRO_DIR([aclocal])
-AM_INIT_AUTOMAKE([foreign -Wall])
+# AM_INIT_AUTOMAKE([foreign -Wall])
 # To install locally
 FB_INITIALIZE([localinstall])
 AC_PREFIX_DEFAULT([/usr/local])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,6 +54,7 @@ endif
 # Set libraries external to this component.
 EXTERNAL_LIBS = -L$(thrift_home)/lib -L$(fb303_home)/lib -L$(hadoop_home)/lib -lfb303 -lthrift -lthriftnb
 EXTERNAL_LIBS += -levent -lpthread
+EXTERNAL_LIBS += $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
 if USE_SCRIBE_HDFS
   EXTERNAL_LIBS += -lhdfs -ljvm
 endif


### PR DESCRIPTION
The bug is due to Scribe calling AM_INIT_AUTOMAKE in both the top of configure.ac and inside FB_INITIALIZE defined in acinclude.m4. The solution is to comment the AM_INIT_AUTOMAKE.

Ref: https://www.bountysource.com/issues/646383-install-on-osx-with-thrift-0-5-0
