### PR TITLE
Fixed copy for serviceList

### DIFF
--- a/src/store.cpp
+++ b/src/store.cpp
@@ -1979,6 +1979,8 @@ shared_ptr<Store> NetworkStore::copy(const std::string &category) {
   store->remoteHost = remoteHost;
   store->remotePort = remotePort;
   store->serviceName = serviceName;
+  store->serviceList = serviceList;
+  store->serviceListDefaultPort = serviceListDefaultPort;
 
   return copied;
 }


### PR DESCRIPTION
The copy() function for NetworkStore was missing the serviceList and serviceListDefaultPort members, making them not work.
